### PR TITLE
update some project metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,13 +47,13 @@
   </prerequisites>
 
   <scm>
-    <connection>scm:svn:http://svn.codehaus.org/mojo/trunk/mojo/build-helper-maven-plugin</connection>
-    <developerConnection>scm:svn:https://svn.codehaus.org/mojo/trunk/mojo/build-helper-maven-plugin</developerConnection>
-    <url>http://svn.codehaus.org/mojo/trunk/mojo/build-helper-maven-plugin</url>
+    <connection>scm:git:https://github.com/mojohaus/build-helper-maven-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:mojohaus/build-helper-maven-plugin.git</developerConnection>
+    <url>https://github.com/mojohaus/build-helper-maven-plugin</url>
   </scm>
   <issueManagement>
-    <system>JIRA</system>
-    <url>http://jira.codehaus.org/browse/MBUILDHELPER</url>
+    <system>GitHub</system>
+    <url>https://github.com/mojohaus/build-helper-maven-plugin/issues</url>
   </issueManagement>
 
   <properties>


### PR DESCRIPTION
The links to SCM and JIRA are either broken or redirect to GitHub, fixed that.
Note that some other stuff, such as metadata from the parent POM, or the maven-changes-plugin configuration still need updating.