### PR TITLE
Fix closing tag in regex-properties usage example

### DIFF
--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -506,7 +506,7 @@ releasedVersion.incrementalVersion
                   <failIfNoMatch>false</failIfNoMatch>
                 </regexPropertySetting>
                 [....]
-              <regexPropertySettings>
+              </regexPropertySettings>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
There is a typo in the example xml. `<regexPropertySettings>` is opened twice and not closed.