### PR TITLE
Issue #3: Fix redirect link to plugin's web site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
   <artifactId>build-helper-maven-plugin</artifactId>
   <version>1.11-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
+  <url>http://www.mojohaus.org/build-helper-maven-plugin/</url>
 
   <name>Build Helper Maven Plugin</name>
   <description>This plugin contains various small independent goals to assist with Maven build lifecycle</description>


### PR DESCRIPTION
Link in effective pom.xml **before** changes:

```xml
  <groupId>org.codehaus.mojo</groupId>
  <artifactId>build-helper-maven-plugin</artifactId>
  <version>1.11-SNAPSHOT</version>
  <packaging>maven-plugin</packaging>
  <name>Build Helper Maven Plugin</name>
  <description>This plugin contains various small independent goals to assist with Maven build lifecycle</description>
  <url>http://www.mojohaus.org/build-helper-maven-plugin/build-helper-maven-plugin</url>
  <inceptionYear>2005</inceptionYear>
```

Link in pom.xml **after** changes:

```xml
  <groupId>org.codehaus.mojo</groupId>
  <artifactId>build-helper-maven-plugin</artifactId>
  <version>1.11-SNAPSHOT</version>
  <packaging>maven-plugin</packaging>
  <name>Build Helper Maven Plugin</name>
  <description>This plugin contains various small independent goals to assist with Maven build lifecycle</description>
  <url>http://www.mojohaus.org/build-helper-maven-plugin/</url>
  <inceptionYear>2005</inceptionYear>
```

Link http://www.mojohaus.org/build-helper-maven-plugin/ is direct.
You can check the link with http://www.wheregoes.com/retracer.php

