### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/src/main/java/org/codehaus/mojo/buildhelper/AttachArtifactMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AttachArtifactMojo.java
@@ -159,7 +159,7 @@ public class AttachArtifactMojo
         throws MojoFailureException
     {
         // check unique of types and classifiers
-        Set<String> extensionClassifiers = new HashSet<String>();
+        Set<String> extensionClassifiers = new HashSet<>();
         for ( Artifact artifact : artifacts )
         {
             String extensionClassifier = artifact.getType() + ":" + artifact.getClassifier();

--- a/src/main/java/org/codehaus/mojo/buildhelper/RegexPropertiesMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/RegexPropertiesMojo.java
@@ -47,7 +47,7 @@ public class RegexPropertiesMojo
      * List of RegexPropertyConfig to apply the regex
      */
     @Parameter( required = false )
-    private List<RegexPropertySetting> regexPropertySettings = new ArrayList<RegexPropertySetting>();
+    private List<RegexPropertySetting> regexPropertySettings = new ArrayList<>();
 
     public void execute()
         throws MojoExecutionException, MojoFailureException

--- a/src/main/java/org/codehaus/mojo/buildhelper/ReserveListenerPortMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/ReserveListenerPortMojo.java
@@ -125,7 +125,7 @@ public class ReserveListenerPortMojo
         }
 
         // Reserve the entire block of ports to guarantee we don't get the same port twice
-        final List<ServerSocket> sockets = new ArrayList<ServerSocket>();
+        final List<ServerSocket> sockets = new ArrayList<>();
         try
         {
             for ( String portName : portNames )
@@ -242,7 +242,7 @@ public class ReserveListenerPortMojo
     {
 
         int difference = ( maxPortNumber - minPortNumber ) + 1;
-        List<Integer> portList = new ArrayList<Integer>( difference );
+        List<Integer> portList = new ArrayList<>(difference);
         List<Integer> reservedPorts = getReservedPorts();
         for ( int i = 0; i < difference; i++ )
         {
@@ -304,7 +304,7 @@ public class ReserveListenerPortMojo
         List<Integer> reservedPorts = (List<Integer>) getPluginContext().get( BUILD_HELPER_RESERVED_PORTS );
         if ( reservedPorts == null )
         {
-            reservedPorts = new ArrayList<Integer>();
+            reservedPorts = new ArrayList<>();
             getPluginContext().put( BUILD_HELPER_RESERVED_PORTS, reservedPorts );
         }
         return reservedPorts;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.
