### PR TITLE
Fixing multiple code quality issues: Squids S1858-S1149-S1854

### DIFF
--- a/src/main/java/org/codehaus/mojo/buildhelper/AttachArtifactMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AttachArtifactMojo.java
@@ -140,7 +140,7 @@ public class AttachArtifactMojo
             getLog().debug( "Current Folder:" + basedir );
 
         }
-        boolean result = mavenSession.getExecutionRootDirectory().equalsIgnoreCase( basedir.toString() );
+        boolean result = mavenSession.getExecutionRootDirectory().equalsIgnoreCase( basedir );
         if ( getLog().isDebugEnabled() )
         {
             if ( result )

--- a/src/main/java/org/codehaus/mojo/buildhelper/OsgiArtifactVersion.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/OsgiArtifactVersion.java
@@ -259,7 +259,7 @@ public class OsgiArtifactVersion
      */
     public String toString()
     {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         if ( majorVersion != null )
         {
             buf.append( majorVersion );

--- a/src/main/java/org/codehaus/mojo/buildhelper/ParseVersionMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/ParseVersionMojo.java
@@ -195,7 +195,7 @@ public class ParseVersionMojo
             return version.toString();
         }
 
-        StringBuffer osgiVersion = new StringBuffer();
+        StringBuilder osgiVersion = new StringBuilder();
         osgiVersion.append( version.getMajorVersion() );
         osgiVersion.append( "." + version.getMinorVersion() );
         osgiVersion.append( "." + version.getIncrementalVersion() );

--- a/src/main/java/org/codehaus/mojo/buildhelper/ReserveListenerPortMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/ReserveListenerPortMojo.java
@@ -283,7 +283,7 @@ public class ReserveListenerPortMojo
         assert minPortNumber != null;
 
         List<Integer> reservedPorts = getReservedPorts();
-        int nextPort = -1;
+        int nextPort;
         if ( reservedPorts.isEmpty() )
         {
             nextPort = minPortNumber;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1858 - “"toString()" should never be called on a String object”.
squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”.
squid:S1854 - “ Dead stores should be removed ”.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1858
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:S1854
Please let me know if you have any questions.
Ayman Abdelghany.