### PR TITLE
Set a property based on the maven.build.timestamp

### DIFF
--- a/src/it/timestamp-timesource/invoker.properties
+++ b/src/it/timestamp-timesource/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=compile

--- a/src/it/timestamp-timesource/module-1/pom.xml
+++ b/src/it/timestamp-timesource/module-1/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>localdomain.localhost</groupId>
+    <artifactId>timestamp-timesource</artifactId>
+    <version>1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>timestamp-timesource-module-1</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Timestamp TimeSource Module 1</name>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <excludes>
+          <exclude>test.properties</exclude>
+        </excludes>
+        <filtering>false</filtering>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>test.properties</include>
+        </includes>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+</project>

--- a/src/it/timestamp-timesource/module-1/src/main/resources/test.properties
+++ b/src/it/timestamp-timesource/module-1/src/main/resources/test.properties
@@ -1,0 +1,2 @@
+module.version=${module.build.timestamp}
+session.version=${session.build.timestamp}

--- a/src/it/timestamp-timesource/module-2/pom.xml
+++ b/src/it/timestamp-timesource/module-2/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>localdomain.localhost</groupId>
+    <artifactId>timestamp-timesource</artifactId>
+    <version>1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>timestamp-timesource-module-2</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Timestamp TimeSource Module 2</name>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <excludes>
+          <exclude>test.properties</exclude>
+        </excludes>
+        <filtering>false</filtering>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>test.properties</include>
+        </includes>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+</project>

--- a/src/it/timestamp-timesource/module-2/src/main/resources/test.properties
+++ b/src/it/timestamp-timesource/module-2/src/main/resources/test.properties
@@ -1,0 +1,2 @@
+module.version=${module.build.timestamp}
+session.version=${session.build.timestamp}

--- a/src/it/timestamp-timesource/pom.xml
+++ b/src/it/timestamp-timesource/pom.xml
@@ -1,0 +1,61 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>timestamp-timesource</artifactId>
+  <version>1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Timestamp TimeSource</name>
+  <description>
+    Tests that a fixed timestamp gets generated
+  </description>
+
+  <modules>
+    <module>module-1</module>
+    <module>module-2</module>
+  </modules>
+
+  <properties>
+    <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss.SSS z</maven.build.timestamp.format>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>module-timestamp-property</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>timestamp-property</goal>
+            </goals>
+            <configuration>
+              <name>module.build.timestamp</name>
+              <pattern>${maven.build.timestamp.format}</pattern>
+              <timeZone>Europe/Amsterdam</timeZone>
+              <!-- <timeSource>current</timeSource> -->
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>session-timestamp-property</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>timestamp-property</goal>
+            </goals>
+            <configuration>
+              <name>session.build.timestamp</name>
+              <pattern>${maven.build.timestamp.format}</pattern>
+              <timeZone>Europe/Amsterdam</timeZone>
+              <timeSource>build</timeSource>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/timestamp-timesource/verify.bsh
+++ b/src/it/timestamp-timesource/verify.bsh
@@ -1,0 +1,49 @@
+import java.io.*;
+import java.util.*;
+
+try
+{
+    File module1File = new File( basedir, "module-1/target/classes/test.properties" );
+    File module2File = new File( basedir, "module-2/target/classes/test.properties" );
+
+    Properties module1Props = new Properties();
+    module1Props.load( new FileInputStream( module1File ) );
+    Properties module2Props = new Properties();
+    module2Props.load( new FileInputStream( module2File ) );
+
+    String module1ModuleVersion = module1Props.getProperty( "module.version" );
+    String module1SessionVersion = module1Props.getProperty( "session.version" );
+    String module2ModuleVersion = module2Props.getProperty( "module.version" );
+    String module2SessionVersion = module2Props.getProperty( "session.version" );
+
+    if ( module1ModuleVersion.indexOf( "${module.build.timestamp}" ) >= 0
+         || module2ModuleVersion.indexOf( "${module.build.timestamp}" ) >= 0)
+    {
+        System.err.println( "Module timestamp not set" );
+        return false;
+    }
+    else if ( module1SessionVersion.indexOf( "${session.build.timestamp}" ) >= 0
+              || module2SessionVersion.indexOf( "${session.build.timestamp}" ) >= 0)
+    {
+        System.err.println( "Session timestamp not set" );
+        return false;
+    }
+
+    if ( module1ModuleVersion.equals( module2ModuleVersion ) )
+    {
+        System.err.println( "Module timestamps should not match by design" );
+        return false;
+    }
+    else if ( !module1SessionVersion.equals( module2SessionVersion ) )
+    {
+        System.err.println( "Session timestamps should match by design" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/main/java/org/codehaus/mojo/buildhelper/TimestampPropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/TimestampPropertyMojo.java
@@ -32,6 +32,7 @@ import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -90,10 +91,30 @@ public class TimestampPropertyMojo
     private String unit;
 
     /**
+     * The source of the time. Valid Values are
+     * <ul>
+     * <li>current</li>
+     * <li>build</li>
+     * </ul>
+     *
+     * @since 3.2.0
+     */
+    @Parameter( defaultValue = "current" )
+    private String timeSource;
+
+    /**
      * The locale to use, for example <code>en,US</code>.
      */
     @Parameter
     private String locale;
+
+    /**
+     * The Maven Session.
+     *
+     * @since 3.2.0
+     */
+    @Parameter( readonly = true, defaultValue = "${session}" )
+    private MavenSession mavenSession;
 
     /**
      * {@inheritDoc}
@@ -199,7 +220,14 @@ public class TimestampPropertyMojo
 
         format.setTimeZone( timeZone );
 
-        defineProperty( name, format.format( calendar.getTime() ) );
+        if ("build".equals(timeSource))
+        {
+            defineProperty( name, format.format( mavenSession.getStartTime() ) );
+        }
+        else
+        {
+            defineProperty( name, format.format( calendar.getTime() ) );
+        }
     }
 
 }

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -641,6 +641,61 @@ tomcat.http.port
 
   The <<<locale>>> and <<<timeZone>>> parameters can be further used to control the build-time behaviour.
 
+* Set a property based on the <<<maven.build.timestamp>>>
+
+  The <<<maven.build.timestamp>>> property does not allow for timezone overrides for obvious reasons.
+  The <<<timestamp-property>>> goal can be used to create one with a local timezone timestamp.
+  But the default implementation uses the <<<current>>> time, which is thus not the same for all modules in a multi module project.
+  The new <<<timeSource>>> parameter with value <<<build>>> now allows the usage of <<<maven.build.timestamp>>> property instead of the <<<current>>> timestamp.
+
+-------------------
+<project>
+  ...
+  <properties>
+    <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss z</maven.build.timestamp.format>
+  </properties>
+  ...
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>module-timestamp-property</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>timestamp-property</goal>
+            </goals>
+            <configuration>
+              <name>module.build.timestamp</name>
+              <pattern>${maven.build.timestamp.format}</pattern>
+              <timeZone>Europe/Amsterdam</timeZone>
+              <!-- <timeSource>current</timeSource> -->
+            </configuration>
+          </execution>
+          <execution>
+            <id>local-timestamp-property</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>timestamp-property</goal>
+            </goals>
+            <configuration>
+              <name>local.build.timestamp</name>
+              <pattern>${maven.build.timestamp.format}</pattern>
+              <timeZone>Europe/Amsterdam</timeZone>
+              <timeSource>build</timeSource>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  ...
+</project>
+-------------------
+
 * Retrieve current host IP address
 
   The <<<local-ip>>> goal can be used to load current host address


### PR DESCRIPTION
The **maven.build.timestamp** property does not allow for timezone overrides for obvious reasons.

The **timestamp-property** goal can be used to create one with a local timezone timestamp. But the default implementation uses the **current** time, which is thus not the same for all modules in a multi module project.

The new **timeSource** parameter with value **build** now allows the usage of **maven.build.timestamp** property instead of the **current** timestamp.
