### PR TITLE
Update to a more OSS friendly version of the library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,9 +99,9 @@
       <version>3.0.24</version>
     </dependency>
     <dependency>
-      <groupId>org.beanshell</groupId>
+      <groupId>org.apache-extras.beanshell</groupId>
       <artifactId>bsh</artifactId>
-      <version>2.0b4</version>
+      <version>2.0b6</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>


### PR DESCRIPTION
I updated the version of `beanshell` that is more OSI and corporate friendly and near as I can tell the product still works as advertised.