### PR TITLE
Add support of timestamp as buildNumber

### DIFF
--- a/src/main/java/org/codehaus/mojo/buildhelper/ParseVersionMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/ParseVersionMojo.java
@@ -162,9 +162,9 @@ public class ParseVersionMojo
         defineProperty( formattedPropertyPrefix + '.' + name, value );
     }
 
-    private void defineVersionProperty( String name, int value )
+    private void defineVersionProperty( String name, long value )
     {
-        defineVersionProperty( name, Integer.toString( value ) );
+        defineVersionProperty( name, Long.toString( value ) );
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/buildhelper/versioning/DefaultVersioning.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/versioning/DefaultVersioning.java
@@ -69,7 +69,7 @@ public class DefaultVersioning
     }
 
     @Override
-    public int getBuildNumber()
+    public long getBuildNumber()
     {
         return this.vi.getBuildNumber();
     }

--- a/src/main/java/org/codehaus/mojo/buildhelper/versioning/VersionInformation.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/versioning/VersionInformation.java
@@ -52,7 +52,7 @@ public class VersionInformation
 
     private int patch;
 
-    private int buildNumber;
+    private long buildNumber;
 
     private String qualifier;
 
@@ -66,7 +66,7 @@ public class VersionInformation
 
             if ( buildNumber != null )
             {
-                setBuildNumber( Integer.parseInt( buildNumber ) );
+                setBuildNumber( Long.parseLong( buildNumber ) );
             }
 
             if ( matcher.group( 7 ) != null )
@@ -165,12 +165,12 @@ public class VersionInformation
         this.patch = patch;
     }
 
-    public int getBuildNumber()
+    public long getBuildNumber()
     {
         return buildNumber;
     }
 
-    public void setBuildNumber( int buildNumber )
+    public void setBuildNumber( long buildNumber )
     {
         this.buildNumber = buildNumber;
     }

--- a/src/main/java/org/codehaus/mojo/buildhelper/versioning/Versioning.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/versioning/Versioning.java
@@ -11,7 +11,7 @@ public interface Versioning
 
     String getAsOSGiVersion();
 
-    int getBuildNumber();
+    long getBuildNumber();
 
     String getQualifier();
 

--- a/src/test/java/org/codehaus/mojo/buildhelper/ParseVersionTest.java
+++ b/src/test/java/org/codehaus/mojo/buildhelper/ParseVersionTest.java
@@ -173,6 +173,21 @@ public class ParseVersionTest
         }
 
         @Test
+        public void testVersionStringWithTimestampBuildNumber()
+        {
+            // Test a version string with a timestamp build number
+            mojo.parseVersion( "1.2.3-20170403100110" );
+
+            assertEquals( "1", props.getProperty( "parsed.majorVersion" ) );
+            assertEquals( "2", props.getProperty( "parsed.minorVersion" ) );
+            assertEquals( "3", props.getProperty( "parsed.incrementalVersion" ) );
+            assertEquals( "", props.getProperty( "parsed.qualifier" ) );
+            assertEquals( "20170403100110", props.getProperty( "parsed.buildNumber" ) );
+            assertEquals( "1.2.3.20170403100110", props.getProperty( "parsed.osgiVersion" ) );
+
+        }
+
+        @Test
         public void testSnapshotVersionStringWithBuildNumber()
         {
             // Test a version string with a build number
@@ -290,7 +305,7 @@ public class ParseVersionTest
 
     }
 
-    
+
     public class TestFormattedVersion
     {
         private Properties props;

--- a/src/test/java/org/codehaus/mojo/buildhelper/ParseVersionTest.java
+++ b/src/test/java/org/codehaus/mojo/buildhelper/ParseVersionTest.java
@@ -305,7 +305,6 @@ public class ParseVersionTest
 
     }
 
-
     public class TestFormattedVersion
     {
         private Properties props;


### PR DESCRIPTION
Hi, we use timestamp as buildNumber (version : 4.1-20170403114142).

This patch avoid NumberFormatException with Integer.parseInt("20170403114142"). I use long instead of int for buildNumber.