### PR TITLE
Issue 67

### DIFF
--- a/src/main/java/org/codehaus/mojo/buildhelper/ParseVersionMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/ParseVersionMojo.java
@@ -15,6 +15,7 @@ import org.codehaus.mojo.buildhelper.versioning.DefaultVersioning;
  *   [propertyPrefix].incrementalVersion
  *   [propertyPrefix].qualifier
  *   [propertyPrefix].buildNumber
+ *   [propertyPrefix].isReleaseVersion (since 3.1.0)
  * </pre>
  * 
  * Where the propertyPrefix is the string set in the mojo parameter. The parsing of the above is based on the following
@@ -180,6 +181,11 @@ public class ParseVersionMojo
         defineVersionProperty( name, Long.toString( value ) );
     }
 
+    private void defineIsReleaseProperty( boolean value )
+    {
+    	defineProperty( propertyPrefix + "." + "isReleaseVersion", Boolean.toString( value ) );
+    }
+
     /**
      * Parse a version String and add the components to a properties object.
      *
@@ -200,6 +206,7 @@ public class ParseVersionMojo
         defineVersionProperty( "minorVersion", artifactVersion.getMinor() );
         defineVersionProperty( "incrementalVersion", artifactVersion.getPatch() );
         defineVersionProperty( "buildNumber", artifactVersion.getBuildNumber() );
+        defineIsReleaseProperty( !artifactVersion.getVersion().endsWith( "SNAPSHOT" ) );
 
         defineVersionProperty( "nextMajorVersion", artifactVersion.getMajor() + 1 );
         defineVersionProperty( "nextMinorVersion", artifactVersion.getMinor() + 1 );

--- a/src/test/java/org/codehaus/mojo/buildhelper/ParseVersionTest.java
+++ b/src/test/java/org/codehaus/mojo/buildhelper/ParseVersionTest.java
@@ -84,6 +84,7 @@ public class ParseVersionTest
             assertEquals( "junk", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "0", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "0.0.0.junk", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "true", props.getProperty( "parsed.isReleaseVersion" ) );
         }
 
         @Test
@@ -99,6 +100,7 @@ public class ParseVersionTest
             assertEquals( "", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "0", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "1.0.0", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "true", props.getProperty( "parsed.isReleaseVersion" ) );
         }
 
         @Test
@@ -113,6 +115,7 @@ public class ParseVersionTest
             assertEquals( "beta-5", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "0", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "2.3.4.beta-5", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "true", props.getProperty( "parsed.isReleaseVersion" ) );
         }
 
         @Test
@@ -127,6 +130,7 @@ public class ParseVersionTest
             assertEquals( "beta_5", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "0", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "2.3.4.beta_5", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "true", props.getProperty( "parsed.isReleaseVersion" ) );
         }
 
         @Test
@@ -141,6 +145,7 @@ public class ParseVersionTest
             assertEquals( "SNAPSHOT", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "0", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "1.2.3.SNAPSHOT", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "false", props.getProperty( "parsed.isReleaseVersion" ) );
         }
 
         @Test
@@ -155,6 +160,7 @@ public class ParseVersionTest
             assertEquals( "SNAPSHOT", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "0", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "2.0.17.SNAPSHOT", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "false", props.getProperty( "parsed.isReleaseVersion" ) );
         }
 
         @Test
@@ -169,6 +175,7 @@ public class ParseVersionTest
             assertEquals( "", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "4", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "1.2.3.4", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "true", props.getProperty( "parsed.isReleaseVersion" ) );
 
         }
 
@@ -184,6 +191,7 @@ public class ParseVersionTest
             assertEquals( "-SNAPSHOT", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "4", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "1.2.3.4-SNAPSHOT", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "false", props.getProperty( "parsed.isReleaseVersion" ) );
         }
 
     }


### PR DESCRIPTION
Implements #67 by adding a new property to the parse-version goal. The since information assumes that this will make it into version 3.1.0.