### PR TITLE
Site: Properly showing 'value' tag on regex-properties usage page

### DIFF
--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -275,7 +275,7 @@ parsedVersion.buildNumber
 -------------------
 
   Apart from the above properties the following properties will be set:
-  
+
 -------------------
 parsedVersion.nextMajorVersion
 parsedVersion.nextMinorVersion
@@ -285,7 +285,7 @@ parsedVersion.nextBuildNumber
 
   And another set of properties is set by using the defined formatting.
   See {{{./parse-version-mojo.html}build-helper:parse-version}}
-  
+
 -------------------
 formattedVersion.majorVersion
 formattedVersion.minorVersion
@@ -296,7 +296,7 @@ formattedVersion.nextMinorVersion
 formattedVersion.nextIncrementalVersion
 formattedVersion.nextBuildNumber
 -------------------
-    
+
 
   The property prefix <<<parsedVersion>>> can be configured using the <<<propertyPrefix>>> parameter.
 
@@ -466,7 +466,7 @@ releasedVersion.qualifier
   </build>
 </project>
 -------------------
-  It is also possible to define port names via resource file(s). Resources in classpath are also supported (artifact 
+  It is also possible to define port names via resource file(s). Resources in classpath are also supported (artifact
   with resource has to be defined in plugin dependencies section).
 
   <<<portNames>>> and <<<urls>>> parameters can be combined.
@@ -539,7 +539,7 @@ tomcat.http.port
             </goals>
             <configuration>
               <name>human.version</name>
-              <value>${project.version}</value>
+              <value>\${project.version}</value>
               <regex>-SNAPSHOT</regex>
               <replacement> pre-release development version</replacement>
               <failIfNoMatch>false</failIfNoMatch>
@@ -578,7 +578,7 @@ tomcat.http.port
               <regexPropertySettings>
                 <regexPropertySetting>
                   <name>human.version</name>
-                  <value>${project.version}</value>
+                  <value>\${project.version}</value>
                   <regex>-SNAPSHOT</regex>
                   <replacement> pre-release development version</replacement>
                   <failIfNoMatch>false</failIfNoMatch>
@@ -737,7 +737,7 @@ tomcat.http.port
 </project>
 -------------------
 
-* Set a property according to whether target files are up to date with respect to their sources 
+* Set a property according to whether target files are up to date with respect to their sources
 
   'Up to date' means that the target file both exists and has a 'last modification timestamp' (<<<java.io.File.lastModified()>>>)
   equal to or later than that of the corresponding source file(s).
@@ -745,7 +745,7 @@ tomcat.http.port
   Source files are computed relative to the <<<fileset>>>'s required <<<directory>>> property.
   If the <<<fileset>>> has an <<<outputDirectory>>> property, target files are computed relative to that;
   otherwise, target files are also computed relative to <<<directory>>>.
-  
+
   The <<<fileset>>> element supports a <<<mapper>>>, whose <<<type>>> can be any of the built-in mappers
   <<<flatten glob identity merge package unpackage>>>. Alternatively, the <<<classname>>> property can specify the
   fully qualified name of a class that implements <<<org.apache.maven.shared.model.fileset.mappers.FileNameMapper>>>.


### PR DESCRIPTION
Escaping '${project.version}' on usage.apt.vm template.

On _**Set a property by applying a regex replacement to a value**_ of the **Usage** page section.

Before, it showed the current version of the plugin since the value was actually being replaced (wich is confusing because the example is removing -SNAPSHOT from that value): `<value>3.0.0</value>`

Now it shows the literal value: `<value>${project.version}</value>`
