### PR TITLE
#86 use triple slash to get file protocol working in URLs on windows

### DIFF
--- a/src/it/reserve-ports-with-urls/pom.xml
+++ b/src/it/reserve-ports-with-urls/pom.xml
@@ -22,7 +22,7 @@
             </goals>
             <configuration>
               <urls>
-                <url>file://${project.basedir}/names2.txt</url>
+                <url>file:///${project.basedir}/names2.txt</url>
               </urls>
             </configuration>
           </execution>
@@ -35,8 +35,8 @@
             <configuration>
               <outputFile>${project.build.directory}/ports.properties</outputFile>
               <urls>
-                <url>file://${project.basedir}/names1.txt</url>
-                <url>file://${project.basedir}/names2.txt</url>
+                <url>file:///${project.basedir}/names1.txt</url>
+                <url>file:///${project.basedir}/names2.txt</url>
               </urls>
             </configuration>
           </execution>

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -494,7 +494,7 @@ releasedVersion.qualifier
             <phase>process-resources</phase>
             <configuration>
               <urls>
-                <url>file://${project.basedir}/names1.txt</url>
+                <url>file:///${project.basedir}/names1.txt</url>
                 <url>classpath:port-names.txt</url>
               </urls>
             </configuration>


### PR DESCRIPTION
fixes #86 