### PR TITLE
Use maven-plugin-plugin in version managed in parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.5</version>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
         </configuration>


### PR DESCRIPTION
Currently used version generates invalid javadoc for
`target/generated-sources/plugin/org/codehaus/mojo/buildhelper/HelpMojo.java`:

```java
   346	    /**
   347	     * Splits the specified text into lines of convenient display length.
   348	     *
   349	     * @param text       The text to split into lines, must not be <code>null</code>.
   350	     * @param indent     The base indentation level of each line, must not be negative.
   351	     * @param indentSize The size of each indentation, must not be negative.
   352	     * @param lineLength The length of the line, must not be negative.
   353	     * @return The sequence of display lines, never <code>null</code>.
   354	     * @throws NegativeArraySizeException if <code>indent < 0</code>
   355	     */
   356	    private static List<String> toLines( String text, int indent, int indentSize, int lineLength )
```
where line 354 contains `<` instead of entity.

3.5.1 m-p-p has it fixed (MPLUGIN-324) and comes from current parent.