### PR TITLE
Fix javadoc errors and warning

### DIFF
--- a/src/main/java/org/codehaus/mojo/buildhelper/ParseVersionMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/ParseVersionMojo.java
@@ -118,28 +118,28 @@ public class ParseVersionMojo
      * This can be used to make a particular format of the major number possible like padding it with zeros etc.
      * 
      * @since 3.0.0
-     * @see https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html#syntax
+     * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html#syntax">Formatter syntax</a>
      */
     @Parameter( defaultValue = "%02d" )
     private String formatMajor;
 
     /**
      * @since 3.0.0
-     * @see https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html#syntax
+     * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html#syntax">Formatter syntax</a>
      */
     @Parameter( defaultValue = "%02d" )
     private String formatMinor;
 
     /**
      * @since 3.0.0
-     * @see https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html#syntax
+     * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html#syntax">Formatter syntax</a>
      */
     @Parameter( defaultValue = "%02d" )
     private String formatIncremental;
 
     /**
      * @since 3.0.0
-     * @see https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html#syntax
+     * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html#syntax">Formatter syntax</a>
      */
     @Parameter( defaultValue = "%02d" )
     private String formatBuildNumber;

--- a/src/main/java/org/codehaus/mojo/buildhelper/ReserveListenerPortMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/ReserveListenerPortMojo.java
@@ -115,8 +115,6 @@ public class ReserveListenerPortMojo
 
     /**
      * Specify true or false if you want the port selection randomized.
-     * <p>
-     * </p>
      *
      * @since 1.10
      */


### PR DESCRIPTION
Fixes errors like
```
[ERROR] .../src/main/java/org/codehaus/mojo/buildhelper/ParseVersionMojo.java:131: warning - Tag @see:illegal character: "47" in "https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html#syntax"
```

I believe we shall follow the *Form 2* of `@see` as described in javadoc reference.

-----

Fixes javadoc warning
```
[WARNING] .../src/main/java/org/codehaus/mojo/buildhelper/ReserveListenerPortMojo.java:119: warning: empty <p> tag
[WARNING] * </p>
```