### PR TITLE
Use primitive to allow it to be resolved by @value in javadoc

### DIFF
--- a/src/main/java/org/codehaus/mojo/buildhelper/ReserveListenerPortMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/ReserveListenerPortMojo.java
@@ -62,7 +62,7 @@ public class ReserveListenerPortMojo
 {
     private static final String BUILD_HELPER_RESERVED_PORTS = "BUILD_HELPER_MIN_PORT";
 
-    private static final Integer FIRST_NON_ROOT_PORT_NUMBER = 1024;
+    private static final int FIRST_NON_ROOT_PORT_NUMBER = 1024;
 
     private static final Integer MAX_PORT_NUMBER = 65535;
 


### PR DESCRIPTION
Currently following is reported:
```
[ERROR] Exit code: 1 - .../src/main/java/org/codehaus/mojo/buildhelper/ReserveListenerPortMojo.java100 error: value does not refer to a constant
[ERROR]      * If {@link #maxPortNumber} is specified, defaults to {@value #FIRST_NON_ROOT_PORT_NUMBER}.
[ERROR]                                                            ^
```
-----

With this fix applied, javadoc looks like:
![javadoc-resolved](https://user-images.githubusercontent.com/11896137/87453459-cd034800-c602-11ea-8b72-11f70d25ad0b.png)

-----
Separate case is for site documentation, where it's still presented as
![site-unresolved](https://user-images.githubusercontent.com/11896137/87453605-0471f480-c603-11ea-937c-21d414c3ff6d.png)
and one has to search to confirm its value.