### PR TITLE
Fixes #108 - released-version does not detect version if maven repository is not configured to look for snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.mojo</groupId>
     <artifactId>mojo-parent</artifactId>
-    <version>50</version>
+    <version>61</version>
   </parent>
 
   <artifactId>build-helper-maven-plugin</artifactId>

--- a/src/it/released-version-existing-asset-issue-108/invoker.properties
+++ b/src/it/released-version-existing-asset-issue-108/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = test
+invoker.buildResult = success
+invoker.settingsFile = src/it/released-version-existing-asset-issue-108/settings-maven-central-no-snapshot.xml

--- a/src/it/released-version-existing-asset-issue-108/pom.xml
+++ b/src/it/released-version-existing-asset-issue-108/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!--
+   We use by intention an existing artifact here, an artifact that exists in maven central to detect it's released version
+    And we are using an external quite specific and outdated asset, that is definitly already in the local maven repo
+    (because if it is in the local maven repo the test will pass always, and Issue #108 cannot be really tested)
+   -->
+  <groupId>org.apache.continuum</groupId>
+  <artifactId>continuum</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>build-helper-maven-plugin-released-version-it</name>
+
+  <build>
+    <defaultGoal>package</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>released-version</id>
+            <goals>
+              <goal>released-version</goal>
+            </goals>
+            <configuration>
+              <propertyPrefix>myReleasedVersion</propertyPrefix>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>mk-target-dir</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <mkdir dir="${project.build.directory}" />
+              </tasks>
+            </configuration>
+          </execution>
+          
+          <execution>
+            <id>echo-released-version</id>
+            <phase>test</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <echo>myReleasedVersion.version=${myReleasedVersion.version}</echo>
+                <echo>myReleasedVersion.majorVersion=${myReleasedVersion.majorVersion}</echo>
+                <echo>myReleasedVersion.minorVersion=${myReleasedVersion.minorVersion}</echo>
+                <echo>myReleasedVersion.incrementalVersion=${myReleasedVersion.incrementalVersion}</echo>
+              </tasks>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/released-version-existing-asset-issue-108/settings-maven-central-no-snapshot.xml
+++ b/src/it/released-version-existing-asset-issue-108/settings-maven-central-no-snapshot.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <profiles>
+    <profile>
+      <id>default</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>default</activeProfile>
+  </activeProfiles>
+</settings>

--- a/src/it/released-version-existing-asset-issue-108/verify.groovy
+++ b/src/it/released-version-existing-asset-issue-108/verify.groovy
@@ -1,0 +1,12 @@
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+// assert latest release of org.apache.continuum:continuum - it's in apache attic, there will be no new releases any more
+assert text.contains("myReleasedVersion.version=1.4.2")
+assert text.contains("myReleasedVersion.majorVersion=1")
+assert text.contains("myReleasedVersion.minorVersion=4")
+assert text.contains("myReleasedVersion.incrementalVersion=2")
+
+return true;

--- a/src/it/released-version-existing-asset/invoker.properties
+++ b/src/it/released-version-existing-asset/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = test
+invoker.buildResult = success
+invoker.settingsFile = src/it/released-version-existing-asset/settings-maven-central.xml

--- a/src/it/released-version-existing-asset/pom.xml
+++ b/src/it/released-version-existing-asset/pom.xml
@@ -1,0 +1,67 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!--
+   We use by intention an existing artifact here, an artifact that exists in maven central to detect it's released version
+   -->
+  <groupId>org.apache.continuum</groupId>
+  <artifactId>continuum</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>build-helper-maven-plugin-released-version-it-mojo-parent</name>
+
+  <build>
+    <defaultGoal>package</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>released-version</id>
+            <goals>
+              <goal>released-version</goal>
+            </goals>
+            <configuration>
+              <propertyPrefix>myReleasedVersion</propertyPrefix>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>mk-target-dir</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <mkdir dir="${project.build.directory}" />
+              </tasks>
+            </configuration>
+          </execution>
+          
+          <execution>
+            <id>echo-released-version</id>
+            <phase>test</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <echo>myReleasedVersion.version=${myReleasedVersion.version}</echo>
+                <echo>myReleasedVersion.majorVersion=${myReleasedVersion.majorVersion}</echo>
+                <echo>myReleasedVersion.minorVersion=${myReleasedVersion.minorVersion}</echo>
+                <echo>myReleasedVersion.incrementalVersion=${myReleasedVersion.incrementalVersion}</echo>
+              </tasks>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/released-version-existing-asset/settings-maven-central.xml
+++ b/src/it/released-version-existing-asset/settings-maven-central.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <profiles>
+    <profile>
+      <id>default</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2/</url>
+          <layout>default</layout>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2/</url>
+          <layout>default</layout>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>default</activeProfile>
+  </activeProfiles>
+</settings>

--- a/src/it/released-version-existing-asset/verify.groovy
+++ b/src/it/released-version-existing-asset/verify.groovy
@@ -1,0 +1,12 @@
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+// assert latest release of org.apache.continuum:continuum - it's in apache attic, there will be no new releases any more
+assert text.contains("myReleasedVersion.version=1.4.2")
+assert text.contains("myReleasedVersion.majorVersion=1")
+assert text.contains("myReleasedVersion.minorVersion=4")
+assert text.contains("myReleasedVersion.incrementalVersion=2")
+
+return true;

--- a/src/main/java/org/codehaus/mojo/buildhelper/ReleasedVersionMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/ReleasedVersionMojo.java
@@ -92,8 +92,17 @@ public class ReleasedVersionMojo
     @SuppressWarnings( "unchecked" )
     public void execute()
     {
+        /*
+         * We use a dummy version "0" here to check for all released version.
+         * Reason: The current project's version is completely irrelevant for the check to retrieve all available versions.
+         * But if the current project's version is a -SNAPSHOT version, only repository from maven settings are
+         * requested that are allowed for snapshots - but we want to query for released versions, not for snapshots.
+         * Using the dummy version "0" which looks like a released version, the repos with releases are requested.
+         * see https://github.com/mojohaus/build-helper-maven-plugin/issues/108
+         */
+        final String DUMMY_VERSION = "0";
         org.apache.maven.artifact.Artifact artifact =
-            artifactFactory.createArtifact( getProject().getGroupId(), getProject().getArtifactId(), getProject().getVersion(), "", "" );
+            artifactFactory.createArtifact( getProject().getGroupId(), getProject().getArtifactId(), DUMMY_VERSION, "", "" );
         try
         {
             ArtifactVersion releasedVersion = null;


### PR DESCRIPTION
* add integration test "released-version-existing-asset" covering existing functionality to get released version for a artifact from maven central
* add integration test to cover the fix for #108
* update to mojo-parent 61 as we need a newer version of `maven-invoker-plugin` that supports the `invoker.settingsFile` property