### PR TITLE
Added a property name to the "sources" parameter for CLI usage

### DIFF
--- a/src/main/java/org/codehaus/mojo/buildhelper/AddSourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AddSourceMojo.java
@@ -47,7 +47,7 @@ public class AddSourceMojo
      *
      * @since 1.0
      */
-    @Parameter( required = true )
+    @Parameter( property = "sources", required = true )
     private File[] sources;
 
     /**


### PR DESCRIPTION
See issue #156. 

This command demonstrate this change in action: 

`mvn dependency:tree -DoutputFile=target/sonar-scan-reports/maven-dependency-tree.txt org.codehaus.mojo:build-helper-maven-plugin:3.4.0-SNAPSHOT:add-source -Dsources="./target/sonar-scan-reports/,./target/someOtherDir/"`

As described in the issue the idea here is to enable the user to generate files for each of the project's Maven modules and teach Maven where to find those files. This way when a plugin that runs later (ie: Sonarqube's scanner) executes Maven will provide it with the locations of these additional source files.