### PR TITLE
Add version prefixes option to released-version goal

### DIFF
--- a/src/it/released-version-version-prefix/invoker.properties
+++ b/src/it/released-version-version-prefix/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = test
+invoker.buildResult = success
+invoker.settingsFile = src/it/released-version-existing-asset/settings-maven-central.xml

--- a/src/it/released-version-version-prefix/pom.xml
+++ b/src/it/released-version-version-prefix/pom.xml
@@ -1,0 +1,68 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!--
+   We use by intention an existing artifact here, an artifact that exists in maven central to detect it's released version
+   -->
+  <groupId>org.apache.continuum</groupId>
+  <artifactId>continuum</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>build-helper-maven-plugin-released-version-it-mojo-parent</name>
+
+  <build>
+    <defaultGoal>package</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>released-version</id>
+            <goals>
+              <goal>released-version</goal>
+            </goals>
+            <configuration>
+              <versionPrefix>1.3</versionPrefix>
+              <propertyPrefix>myReleasedVersion</propertyPrefix>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>mk-target-dir</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <mkdir dir="${project.build.directory}" />
+              </tasks>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>echo-released-version</id>
+            <phase>test</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <echo>myReleasedVersion.version=${myReleasedVersion.version}</echo>
+                <echo>myReleasedVersion.majorVersion=${myReleasedVersion.majorVersion}</echo>
+                <echo>myReleasedVersion.minorVersion=${myReleasedVersion.minorVersion}</echo>
+                <echo>myReleasedVersion.incrementalVersion=${myReleasedVersion.incrementalVersion}</echo>
+              </tasks>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/released-version-version-prefix/settings-maven-central.xml
+++ b/src/it/released-version-version-prefix/settings-maven-central.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <profiles>
+    <profile>
+      <id>default</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2/</url>
+          <layout>default</layout>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2/</url>
+          <layout>default</layout>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>default</activeProfile>
+  </activeProfiles>
+</settings>

--- a/src/it/released-version-version-prefix/verify.groovy
+++ b/src/it/released-version-version-prefix/verify.groovy
@@ -1,0 +1,12 @@
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+// assert latest release of org.apache.continuum:continuum - it's in apache attic, there will be no new releases any more
+assert text.contains("myReleasedVersion.version=1.3.8")
+assert text.contains("myReleasedVersion.majorVersion=1")
+assert text.contains("myReleasedVersion.minorVersion=3")
+assert text.contains("myReleasedVersion.incrementalVersion=8")
+
+return true;

--- a/src/main/java/org/codehaus/mojo/buildhelper/ReleasedVersionMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/ReleasedVersionMojo.java
@@ -74,6 +74,13 @@ public class ReleasedVersionMojo
     private List<ArtifactRepository> remoteArtifactRepositories;
 
     /**
+     * Returned version must before with the version prefix. Allows searching for maximum minor version given a major
+     * version, or maximum increment version given a minor version.
+     */
+    @Parameter( property = "releasedVersion.versionPrefix" )
+    private String versionPrefix = "";
+
+    /**
      * Prefix string to use for the set of version properties.
      */
     @Parameter( defaultValue = "releasedVersion" )
@@ -111,7 +118,8 @@ public class ReleasedVersionMojo
                                                                   remoteArtifactRepositories );
             for ( ArtifactVersion version : versions )
             {
-                if ( !ArtifactUtils.isSnapshot( version.toString() )
+                if ( version.toString().startsWith(versionPrefix)
+                    && !ArtifactUtils.isSnapshot( version.toString() )
                     && ( releasedVersion == null || version.compareTo( releasedVersion ) > 0 ) )
                 {
                     releasedVersion = version;


### PR DESCRIPTION
Allow running the released-version goal with optional parameter versionPrefix, which filters the matched released versions to versions that begin with that prefix.

For example, if the released versions are 1.3.1, 1.3.2, 1.4.1, 1.4.2, and you run `mvn build-helper:released-version` normally, it will find version 1.4.2 as the latest released version.

This commit makes it so if you give it the parameter versionPrefix=1.3, then it will find 1.3.2 instead.

You can also pass in the versionPrefix via a property:

   mvn build-helper:released-version -DreleasedVersion.versionPrefix=1.3