### PR TITLE
Add skipIfMissing flag

### DIFF
--- a/src/it/add-resource-skip-if-missing/invoker.properties
+++ b/src/it/add-resource-skip-if-missing/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = -X generate-sources
+invoker.buildResult = success

--- a/src/it/add-resource-skip-if-missing/pom.xml
+++ b/src/it/add-resource-skip-if-missing/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>build-helper</groupId>
+    <artifactId>integration-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/not-existing</directory>
+                                    <targetPath>does-not-matter</targetPath>
+                                </resource>
+                            </resources>
+                            <skipIfMissing>true</skipIfMissing>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/add-resource-skip-if-missing/pom.xml
+++ b/src/it/add-resource-skip-if-missing/pom.xml
@@ -26,7 +26,7 @@
                                     <targetPath>does-not-matter</targetPath>
                                 </resource>
                             </resources>
-                            <skipIfMissing>true</skipIfMissing>
+                            <skipAddResourceIfMissing>true</skipAddResourceIfMissing>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/add-resource-skip-if-missing/verify.groovy
+++ b/src/it/add-resource-skip-if-missing/verify.groovy
@@ -5,7 +5,7 @@ String text = file.getText("utf-8");
 
 
 
-assert text.contains("skipIfMissing = true");
+assert text.contains("skipAddResourceIfMissing = true");
 assert text.contains("Skipping directory: ");
 assert text.contains("build-helper-maven-plugin/target/it/add-resource-skip-if-missing/not-existing, because it does not exist.");
 

--- a/src/it/add-resource-skip-if-missing/verify.groovy
+++ b/src/it/add-resource-skip-if-missing/verify.groovy
@@ -1,0 +1,12 @@
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+
+
+assert text.contains("skipIfMissing = true");
+assert text.contains("Skipping directory: ");
+assert text.contains("build-helper-maven-plugin/target/it/add-resource-skip-if-missing/not-existing, because it does not exist.");
+
+return true;

--- a/src/it/add-resource-skip-if-missing/verify.groovy
+++ b/src/it/add-resource-skip-if-missing/verify.groovy
@@ -3,10 +3,8 @@ assert file.exists();
 
 String text = file.getText("utf-8");
 
-
-
 assert text.contains("skipAddResourceIfMissing = true");
 assert text.contains("Skipping directory: ");
-assert text.contains("build-helper-maven-plugin/target/it/add-resource-skip-if-missing/not-existing, because it does not exist.");
+assert text.contains("not-existing, because it does not exist");
 
 return true;

--- a/src/it/add-source-skip-if-missing/invoker.properties
+++ b/src/it/add-source-skip-if-missing/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = -X generate-sources
+invoker.buildResult = success

--- a/src/it/add-source-skip-if-missing/pom.xml
+++ b/src/it/add-source-skip-if-missing/pom.xml
@@ -23,7 +23,7 @@
                             <sources>
                                 <source>${project.basedir}/not-existing</source>
                             </sources>
-                            <skipIfMissing>true</skipIfMissing>
+                            <skipAddSourceIfMissing>true</skipAddSourceIfMissing>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/add-source-skip-if-missing/pom.xml
+++ b/src/it/add-source-skip-if-missing/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>build-helper</groupId>
+    <artifactId>integration-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/not-existing</source>
+                            </sources>
+                            <skipIfMissing>true</skipIfMissing>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/add-source-skip-if-missing/verify.groovy
+++ b/src/it/add-source-skip-if-missing/verify.groovy
@@ -1,0 +1,12 @@
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+
+
+assert text.contains("skipIfMissing = true");
+assert text.contains("Skipping directory: ");
+assert text.contains("build-helper-maven-plugin/target/it/add-source-skip-if-missing/not-existing, because it does not exist.");
+
+return true;

--- a/src/it/add-source-skip-if-missing/verify.groovy
+++ b/src/it/add-source-skip-if-missing/verify.groovy
@@ -3,10 +3,8 @@ assert file.exists();
 
 String text = file.getText("utf-8");
 
-
-
 assert text.contains("skipAddSourceIfMissing = true");
 assert text.contains("Skipping directory: ");
-assert text.contains("build-helper-maven-plugin/target/it/add-source-skip-if-missing/not-existing, because it does not exist.");
+assert text.contains("not-existing, because it does not exist.");
 
 return true;

--- a/src/it/add-source-skip-if-missing/verify.groovy
+++ b/src/it/add-source-skip-if-missing/verify.groovy
@@ -5,7 +5,7 @@ String text = file.getText("utf-8");
 
 
 
-assert text.contains("skipIfMissing = true");
+assert text.contains("skipAddSourceIfMissing = true");
 assert text.contains("Skipping directory: ");
 assert text.contains("build-helper-maven-plugin/target/it/add-source-skip-if-missing/not-existing, because it does not exist.");
 

--- a/src/it/add-test-resource-skip-if-missing/invoker.properties
+++ b/src/it/add-test-resource-skip-if-missing/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = -X generate-sources
+invoker.buildResult = success

--- a/src/it/add-test-resource-skip-if-missing/pom.xml
+++ b/src/it/add-test-resource-skip-if-missing/pom.xml
@@ -26,7 +26,7 @@
                                     <targetPath>does-not-matter</targetPath>
                                 </resource>
                             </resources>
-                            <skipIfMissing>true</skipIfMissing>
+                            <skipAddTestResourceIfMissing>true</skipAddTestResourceIfMissing>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/add-test-resource-skip-if-missing/pom.xml
+++ b/src/it/add-test-resource-skip-if-missing/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>build-helper</groupId>
+    <artifactId>integration-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/not-existing</directory>
+                                    <targetPath>does-not-matter</targetPath>
+                                </resource>
+                            </resources>
+                            <skipIfMissing>true</skipIfMissing>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/add-test-resource-skip-if-missing/verify.groovy
+++ b/src/it/add-test-resource-skip-if-missing/verify.groovy
@@ -3,10 +3,8 @@ assert file.exists();
 
 String text = file.getText("utf-8");
 
-
-
 assert text.contains("skipAddTestResourceIfMissing = true");
 assert text.contains("Skipping directory: ");
-assert text.contains("build-helper-maven-plugin/target/it/add-test-resource-skip-if-missing/not-existing, because it does not exist.");
+assert text.contains("not-existing, because it does not exist.");
 
 return true;

--- a/src/it/add-test-resource-skip-if-missing/verify.groovy
+++ b/src/it/add-test-resource-skip-if-missing/verify.groovy
@@ -5,7 +5,7 @@ String text = file.getText("utf-8");
 
 
 
-assert text.contains("skipIfMissing = true");
+assert text.contains("skipAddTestResourceIfMissing = true");
 assert text.contains("Skipping directory: ");
 assert text.contains("build-helper-maven-plugin/target/it/add-test-resource-skip-if-missing/not-existing, because it does not exist.");
 

--- a/src/it/add-test-resource-skip-if-missing/verify.groovy
+++ b/src/it/add-test-resource-skip-if-missing/verify.groovy
@@ -1,0 +1,12 @@
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+
+
+assert text.contains("skipIfMissing = true");
+assert text.contains("Skipping directory: ");
+assert text.contains("build-helper-maven-plugin/target/it/add-test-resource-skip-if-missing/not-existing, because it does not exist.");
+
+return true;

--- a/src/it/add-test-source-skip-if-missing/invoker.properties
+++ b/src/it/add-test-source-skip-if-missing/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = -X generate-sources
+invoker.buildResult = success

--- a/src/it/add-test-source-skip-if-missing/pom.xml
+++ b/src/it/add-test-source-skip-if-missing/pom.xml
@@ -23,7 +23,7 @@
                             <sources>
                                 <source>${project.basedir}/not-existing</source>
                             </sources>
-                            <skipIfMissing>true</skipIfMissing>
+                            <skipAddTestSourceIfMissing>true</skipAddTestSourceIfMissing>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/add-test-source-skip-if-missing/pom.xml
+++ b/src/it/add-test-source-skip-if-missing/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>build-helper</groupId>
+    <artifactId>integration-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/not-existing</source>
+                            </sources>
+                            <skipIfMissing>true</skipIfMissing>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/add-test-source-skip-if-missing/verify.groovy
+++ b/src/it/add-test-source-skip-if-missing/verify.groovy
@@ -5,7 +5,7 @@ String text = file.getText("utf-8");
 
 
 
-assert text.contains("skipIfMissing = true");
+assert text.contains("skipAddTestSourceIfMissing = true");
 assert text.contains("Skipping directory: ");
 assert text.contains("build-helper-maven-plugin/target/it/add-test-source-skip-if-missing/not-existing, because it does not exist.");
 

--- a/src/it/add-test-source-skip-if-missing/verify.groovy
+++ b/src/it/add-test-source-skip-if-missing/verify.groovy
@@ -1,0 +1,12 @@
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+
+
+assert text.contains("skipIfMissing = true");
+assert text.contains("Skipping directory: ");
+assert text.contains("build-helper-maven-plugin/target/it/add-test-source-skip-if-missing/not-existing, because it does not exist.");
+
+return true;

--- a/src/it/add-test-source-skip-if-missing/verify.groovy
+++ b/src/it/add-test-source-skip-if-missing/verify.groovy
@@ -3,10 +3,8 @@ assert file.exists();
 
 String text = file.getText("utf-8");
 
-
-
 assert text.contains("skipAddTestSourceIfMissing = true");
 assert text.contains("Skipping directory: ");
-assert text.contains("build-helper-maven-plugin/target/it/add-test-source-skip-if-missing/not-existing, because it does not exist.");
+assert text.contains("not-existing, because it does not exist.");
 
 return true;

--- a/src/main/java/org/codehaus/mojo/buildhelper/AbstractAddResourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AbstractAddResourceMojo.java
@@ -48,14 +48,6 @@ public abstract class AbstractAddResourceMojo extends AbstractMojo {
     private MavenProject project;
 
     /**
-     * If a resource directory does not exist, do not add it as a root.
-     *
-     * @since 3.4.1
-     */
-    @Parameter(property = "skipIfMissing", defaultValue = "false")
-    private boolean skipIfMissing;
-
-    /**
      * Main plugin execution
      */
     public void execute() {
@@ -75,7 +67,7 @@ public abstract class AbstractAddResourceMojo extends AbstractMojo {
                 resource.setDirectory(resourceDir.getAbsolutePath());
             }
 
-            if (skipIfMissing && !resourceDir.exists()) {
+            if (isSkipIfMissing() && !resourceDir.exists()) {
                 if (getLog().isDebugEnabled()) {
                     getLog().debug("Skipping directory: " + resourceDir + ", because it does not exist.");
                 }
@@ -84,6 +76,8 @@ public abstract class AbstractAddResourceMojo extends AbstractMojo {
             }
         }
     }
+
+    protected abstract boolean isSkipIfMissing();
 
     protected abstract boolean isSkip();
 

--- a/src/main/java/org/codehaus/mojo/buildhelper/AbstractAddResourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AbstractAddResourceMojo.java
@@ -48,6 +48,14 @@ public abstract class AbstractAddResourceMojo extends AbstractMojo {
     private MavenProject project;
 
     /**
+     * If a resource directory does not exist, do not add it as a root.
+     *
+     * @since 3.4.1
+     */
+    @Parameter(property = "skipIfMissing", defaultValue = "false")
+    private boolean skipIfMissing;
+
+    /**
      * Main plugin execution
      */
     public void execute() {
@@ -67,7 +75,13 @@ public abstract class AbstractAddResourceMojo extends AbstractMojo {
                 resource.setDirectory(resourceDir.getAbsolutePath());
             }
 
-            addResource(resource);
+            if (skipIfMissing && !resourceDir.exists()) {
+                if (getLog().isDebugEnabled()) {
+                    getLog().debug("Skipping directory: " + resourceDir + ", because it does not exist.");
+                }
+            } else {
+                addResource(resource);
+            }
         }
     }
 

--- a/src/main/java/org/codehaus/mojo/buildhelper/AddResourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AddResourceMojo.java
@@ -52,7 +52,7 @@ public class AddResourceMojo extends AbstractAddResourceMojo {
      * @since 3.5.0
      */
     @Parameter(property = "buildhelper.addresource.skipIfMissing", defaultValue = "false")
-    private boolean skipIfMissing;
+    private boolean skipAddResourceIfMissing;
 
     public void addResource(Resource resource) {
         getProject().addResource(resource);
@@ -62,7 +62,7 @@ public class AddResourceMojo extends AbstractAddResourceMojo {
     }
 
     protected boolean isSkipIfMissing() {
-        return skipIfMissing;
+        return skipAddResourceIfMissing;
     }
 
     protected boolean isSkip() {

--- a/src/main/java/org/codehaus/mojo/buildhelper/AddResourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AddResourceMojo.java
@@ -46,11 +46,23 @@ public class AddResourceMojo extends AbstractAddResourceMojo {
     @Parameter(property = "buildhelper.addresource.skip", defaultValue = "false")
     private boolean skipAddResource;
 
+    /**
+     * If a resource directory does not exist, do not add it as a root.
+     *
+     * @since 3.5.0
+     */
+    @Parameter(property = "buildhelper.addresource.skipIfMissing", defaultValue = "false")
+    private boolean skipIfMissing;
+
     public void addResource(Resource resource) {
         getProject().addResource(resource);
         if (getLog().isDebugEnabled()) {
             getLog().debug("Added resource: " + resource.getDirectory());
         }
+    }
+
+    protected boolean isSkipIfMissing() {
+        return skipIfMissing;
     }
 
     protected boolean isSkip() {

--- a/src/main/java/org/codehaus/mojo/buildhelper/AddSourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AddSourceMojo.java
@@ -55,6 +55,14 @@ public class AddSourceMojo extends AbstractMojo {
     private MavenProject project;
 
     /**
+     * If a directory does not exist, do not add it as a source root.
+     *
+     * @since 3.4.1
+     */
+    @Parameter(property = "skipIfMissing", defaultValue = "false")
+    private boolean skipIfMissing;
+
+    /**
      * Skip plugin execution.
      *
      * @since 3.5.0
@@ -71,9 +79,15 @@ public class AddSourceMojo extends AbstractMojo {
         }
 
         for (File source : sources) {
-            this.project.addCompileSourceRoot(source.getAbsolutePath());
-            if (getLog().isInfoEnabled()) {
-                getLog().info("Source directory: " + source + " added.");
+            if (skipIfMissing && !source.exists()) {
+                if (getLog().isDebugEnabled()) {
+                    getLog().debug("Skipping directory: " + source + ", because it does not exist.");
+                }
+            } else {
+                this.project.addCompileSourceRoot(source.getAbsolutePath());
+                if (getLog().isInfoEnabled()) {
+                    getLog().info("Source directory: " + source + " added.");
+                }
             }
         }
     }

--- a/src/main/java/org/codehaus/mojo/buildhelper/AddSourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AddSourceMojo.java
@@ -55,20 +55,20 @@ public class AddSourceMojo extends AbstractMojo {
     private MavenProject project;
 
     /**
-     * If a directory does not exist, do not add it as a source root.
-     *
-     * @since 3.5.0
-     */
-    @Parameter(property = "buildhelper.addsource.skipIfMissing", defaultValue = "false")
-    private boolean skipIfMissing;
-
-    /**
      * Skip plugin execution.
      *
      * @since 3.5.0
      */
     @Parameter(property = "buildhelper.addsource.skip", defaultValue = "false")
     private boolean skipAddSource;
+
+    /**
+     * If a directory does not exist, do not add it as a source root.
+     *
+     * @since 3.5.0
+     */
+    @Parameter(property = "buildhelper.addsource.skipIfMissing", defaultValue = "false")
+    private boolean skipAddSourceIfMissing;
 
     public void execute() {
         if (skipAddSource) {
@@ -79,7 +79,7 @@ public class AddSourceMojo extends AbstractMojo {
         }
 
         for (File source : sources) {
-            if (skipIfMissing && !source.exists()) {
+            if (skipAddSourceIfMissing && !source.exists()) {
                 if (getLog().isDebugEnabled()) {
                     getLog().debug("Skipping directory: " + source + ", because it does not exist.");
                 }

--- a/src/main/java/org/codehaus/mojo/buildhelper/AddSourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AddSourceMojo.java
@@ -57,9 +57,9 @@ public class AddSourceMojo extends AbstractMojo {
     /**
      * If a directory does not exist, do not add it as a source root.
      *
-     * @since 3.4.1
+     * @since 3.5.0
      */
-    @Parameter(property = "skipIfMissing", defaultValue = "false")
+    @Parameter(property = "buildhelper.addsource.skipIfMissing", defaultValue = "false")
     private boolean skipIfMissing;
 
     /**

--- a/src/main/java/org/codehaus/mojo/buildhelper/AddTestResourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AddTestResourceMojo.java
@@ -52,7 +52,7 @@ public class AddTestResourceMojo extends AbstractAddResourceMojo {
      * @since 3.5.0
      */
     @Parameter(property = "buildhelper.addtestresource.skipIfMissing", defaultValue = "false")
-    private boolean skipIfMissing;
+    private boolean skipAddTestResourceIfMissing;
 
     /**
      * Add the resource to the project.
@@ -72,6 +72,6 @@ public class AddTestResourceMojo extends AbstractAddResourceMojo {
     }
 
     protected boolean isSkipIfMissing() {
-        return skipIfMissing;
+        return skipAddTestResourceIfMissing;
     }
 }

--- a/src/main/java/org/codehaus/mojo/buildhelper/AddTestResourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AddTestResourceMojo.java
@@ -47,6 +47,14 @@ public class AddTestResourceMojo extends AbstractAddResourceMojo {
     private boolean skipAddTestResource;
 
     /**
+     * If a test resource directory does not exist, do not add it as a root.
+     *
+     * @since 3.5.0
+     */
+    @Parameter(property = "buildhelper.addtestresource.skipIfMissing", defaultValue = "false")
+    private boolean skipIfMissing;
+
+    /**
      * Add the resource to the project.
      *
      * @param resource the resource to add
@@ -61,5 +69,9 @@ public class AddTestResourceMojo extends AbstractAddResourceMojo {
     @Override
     protected boolean isSkip() {
         return skipAddTestResource;
+    }
+
+    protected boolean isSkipIfMissing() {
+        return skipIfMissing;
     }
 }

--- a/src/main/java/org/codehaus/mojo/buildhelper/AddTestSourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AddTestSourceMojo.java
@@ -40,6 +40,7 @@ import org.apache.maven.project.MavenProject;
  */
 @Mojo(name = "add-test-source", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, threadSafe = true)
 public class AddTestSourceMojo extends AbstractMojo {
+
     /**
      * Additional test source directories.
      *
@@ -53,6 +54,14 @@ public class AddTestSourceMojo extends AbstractMojo {
      */
     @Parameter(readonly = true, defaultValue = "${project}")
     private MavenProject project;
+
+    /**
+     * If a directory does not exist, do not add it as a test source root.
+     *
+     * @since 3.4.1
+     */
+    @Parameter(property = "skipIfMissing", defaultValue = "false")
+    private boolean skipIfMissing;
 
     /**
      * Skip plugin execution.
@@ -71,9 +80,15 @@ public class AddTestSourceMojo extends AbstractMojo {
         }
 
         for (File source : sources) {
-            this.project.addTestCompileSourceRoot(source.getAbsolutePath());
-            if (getLog().isInfoEnabled()) {
-                getLog().info("Test Source directory: " + source + " added.");
+            if (skipIfMissing && !source.exists()) {
+                if (getLog().isDebugEnabled()) {
+                    getLog().debug("Skipping directory: " + source + ", because it does not exist.");
+                }
+            } else {
+                this.project.addTestCompileSourceRoot(source.getAbsolutePath());
+                if (getLog().isInfoEnabled()) {
+                    getLog().info("Test Source directory: " + source + " added.");
+                }
             }
         }
     }

--- a/src/main/java/org/codehaus/mojo/buildhelper/AddTestSourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AddTestSourceMojo.java
@@ -58,9 +58,9 @@ public class AddTestSourceMojo extends AbstractMojo {
     /**
      * If a directory does not exist, do not add it as a test source root.
      *
-     * @since 3.4.1
+     * @since 3.5.0
      */
-    @Parameter(property = "skipIfMissing", defaultValue = "false")
+    @Parameter(property = "buildhelper.addtestsource.skipIfMissing", defaultValue = "false")
     private boolean skipIfMissing;
 
     /**

--- a/src/main/java/org/codehaus/mojo/buildhelper/AddTestSourceMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/AddTestSourceMojo.java
@@ -56,20 +56,20 @@ public class AddTestSourceMojo extends AbstractMojo {
     private MavenProject project;
 
     /**
-     * If a directory does not exist, do not add it as a test source root.
-     *
-     * @since 3.5.0
-     */
-    @Parameter(property = "buildhelper.addtestsource.skipIfMissing", defaultValue = "false")
-    private boolean skipIfMissing;
-
-    /**
      * Skip plugin execution.
      *
      * @since 3.5.0
      */
     @Parameter(property = "buildhelper.addtestsource.skip", defaultValue = "false")
     private boolean skipAddTestSource;
+
+    /**
+     * If a directory does not exist, do not add it as a test source root.
+     *
+     * @since 3.5.0
+     */
+    @Parameter(property = "buildhelper.addtestsource.skipIfMissing", defaultValue = "false")
+    private boolean skipAddTestSourceIfMissing;
 
     public void execute() {
         if (skipAddTestSource) {
@@ -80,7 +80,7 @@ public class AddTestSourceMojo extends AbstractMojo {
         }
 
         for (File source : sources) {
-            if (skipIfMissing && !source.exists()) {
+            if (skipAddTestSourceIfMissing && !source.exists()) {
                 if (getLog().isDebugEnabled()) {
                     getLog().debug("Skipping directory: " + source + ", because it does not exist.");
                 }


### PR DESCRIPTION
- build-helper:add-source
- build-helper:add-test-source
- build-helper:add-resource
- build-helper:add-test-resource

add flag `<skipIfMissing>true|false<skipIfMissing>`. If this flag is set
to true and a directory that should be added does not exist, skip it and
do not add it to the build. This allows a multi module build to use
these plugins unconditionally. E.g.

```
<plugin>
    <groupId>org.codehaus.mojo</groupId>
    <artifactId>build-helper-maven-plugin</artifactId>
    <executions>
        <execution>
            <id>kotlin</id>
            <goals>
                <goal>add-source</goal>
            </goals>
            <phase>generate-sources</phase>
            <configuration>
                <skipIfMissing>true</skipIfMissing>
                <sources>
                    <source>${project.basedir}/src/main/kotlin</source>
                </sources>
            </configuration>
        </execution>
    </executions>
</plugin>
```

can be configured unconditionally and only modules that actually have a
`src/main/kotlin` folder will add this as a compile root.
