### PR TITLE
Fix goal in usage add-test-resource example

### DIFF
--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -127,7 +127,7 @@ Usage
             <id>add-resource</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>add-resource</goal>
+              <goal>add-test-resource</goal>
             </goals>
             <configuration>
               <resources>


### PR DESCRIPTION
The text above mentions "Another goal is called `add-test-resource`
...", but the example used `add-resource` as goal.