### PR TITLE
update the documentation for adding more resource directories

### DIFF
--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -127,7 +127,7 @@ Usage
             <id>add-resource</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>add-test-resource</goal>
+              <goal>add-resource</goal>
             </goals>
             <configuration>
               <resources>


### PR DESCRIPTION
When reading the Usage page for 'Add more resource directories to your project' the example maven configuration is incorrect. The description is describing adding resources to the project but the goal is adding them to the test resources.